### PR TITLE
Allowing passing of seeded RandomState objects.

### DIFF
--- a/arspy/ars.py
+++ b/arspy/ars.py
@@ -30,7 +30,7 @@ def adaptive_rejection_sampling(logpdf: callable,
                                 a: float, b: float,
                                 domain: Tuple[float, float],
                                 n_samples: int,
-                                seed=None, random_stream=None):
+                                random_stream=None):
     """
     Adaptive rejection sampling samples exactly (all samples are i.i.d) and efficiently from any univariate log-concave distribution. The basic idea is to successively determine an envelope of straight-line segments to construct an increasingly accurate approximation of the logarithm.
     It does not require any normalization of the target distribution.
@@ -66,15 +66,11 @@ def adaptive_rejection_sampling(logpdf: callable,
     n_samples: int
         Number of samples to draw.
 
-    seed : int, optional
-        Random seed to use.
-        Defaults to `None`.
-
     random_stream : RandomState, optional
-        Seeded random number generator object with same interface as NumPy
-        RandomState. Alternative to specifying `seed` for use in code which
-        already has instantiated a random number generator. Will be ignored if
-        `seed` is not `None`. Defaults to `None`.
+        Seeded random number generator object with same interface as a NumPy
+        RandomState object. Defaults to `None` in which case a NumPy
+        RandomState seeded from `/dev/urandom` if available or the clock if not
+        will be used.
 
     Returns
     ----------
@@ -105,13 +101,8 @@ def adaptive_rejection_sampling(logpdf: callable,
     assert(domain[1] >= domain[0]), "Invalid domain, it must hold: domain[1] >= domain[0]."
     assert(n_samples >= 0), "Number of samples must be >= 0."
 
-    assert seed is None or isinstance(seed, (int, np.int)), "Seed must be integer value or `None`!"
-    assert seed is None or 0 <= seed <= 2 ** 32 - 1, "Integer seeds must be >=0 and <= 2 ** 32 - 1"
-    assert seed is None or random_stream is None, (
-        "Only one of `seed` or `random_stream` should be specified.")
-
     if random_stream is None:
-        random_stream = RandomState(seed)
+        random_stream = RandomState()
 
     if a >= b or isinf(a) or isinf(b) or a < domain[0] or b > domain[1]:
         raise ValueError("invalid a and b")

--- a/arspy/ars.py
+++ b/arspy/ars.py
@@ -30,7 +30,7 @@ def adaptive_rejection_sampling(logpdf: callable,
                                 a: float, b: float,
                                 domain: Tuple[float, float],
                                 n_samples: int,
-                                seed=None):
+                                seed=None, random_stream=None):
     """
     Adaptive rejection sampling samples exactly (all samples are i.i.d) and efficiently from any univariate log-concave distribution. The basic idea is to successively determine an envelope of straight-line segments to construct an increasingly accurate approximation of the logarithm.
     It does not require any normalization of the target distribution.
@@ -70,6 +70,12 @@ def adaptive_rejection_sampling(logpdf: callable,
         Random seed to use.
         Defaults to `None`.
 
+    random_stream : RandomState, optional
+        Seeded random number generator object with same interface as NumPy
+        RandomState. Alternative to specifying `seed` for use in code which
+        already has instantiated a random number generator. Will be ignored if
+        `seed` is not `None`. Defaults to `None`.
+
     Returns
     ----------
     samples : list
@@ -101,8 +107,11 @@ def adaptive_rejection_sampling(logpdf: callable,
 
     assert seed is None or isinstance(seed, (int, np.int)), "Seed must be integer value or `None`!"
     assert seed is None or 0 <= seed <= 2 ** 32 - 1, "Integer seeds must be >=0 and <= 2 ** 32 - 1"
+    assert seed is None or random_stream is None, (
+        "Only one of `seed` or `random_stream` should be specified.")
 
-    random_stream = RandomState(seed)
+    if random_stream is None:
+        random_stream = RandomState(seed)
 
     if a >= b or isinf(a) or isinf(b) or a < domain[0] or b > domain[1]:
         raise ValueError("invalid a and b")

--- a/arspy/tests/test_ars.py
+++ b/arspy/tests/test_ars.py
@@ -48,7 +48,7 @@ tests = {
 }
 
 
-def _run(test_name, use_random_stream=False):
+def _run(test_name):
     input_dict = tests[test_name]
 
     # name = input_dict["name"]
@@ -59,15 +59,10 @@ def _run(test_name, use_random_stream=False):
 
     logpdf = input_dict["func"]
 
-    if use_random_stream:
-        python_result = adaptive_rejection_sampling(
-            logpdf=logpdf, a=a, b=b, domain=domain, n_samples=n_samples, seed=1
-        )
-    else:
-        python_result = adaptive_rejection_sampling(
-            logpdf=logpdf, a=a, b=b, domain=domain, n_samples=n_samples,
-            random_stream=np.random.RandomState(seed=1)
-        )
+    python_result = adaptive_rejection_sampling(
+        logpdf=logpdf, a=a, b=b, domain=domain, n_samples=n_samples,
+        random_stream=np.random.RandomState(seed=1)
+    )
 
     # load old result computed by other implementation (julia)
     julia_result = np.load(input_dict["data"])
@@ -76,15 +71,12 @@ def _run(test_name, use_random_stream=False):
 
 
 def test_gaussian():
-    _run("1d-gaussian", True)
-    _run("1d-gaussian", False)
+    _run("1d-gaussian")
 
 
 def test_half_gaussian():
-    _run("1d-half-gaussian", True)
-    _run("1d-half-gaussian", False)
+    _run("1d-half-gaussian")
 
 
 def test_relativistic_monte_carlo_logpdf():
-    _run("relativistic_monte_carlo_logpdf", True)
-    _run("relativistic_monte_carlo_logpdf", False)
+    _run("relativistic_monte_carlo_logpdf")

--- a/arspy/tests/test_ars.py
+++ b/arspy/tests/test_ars.py
@@ -48,7 +48,7 @@ tests = {
 }
 
 
-def _run(test_name):
+def _run(test_name, use_random_stream=False):
     input_dict = tests[test_name]
 
     # name = input_dict["name"]
@@ -59,9 +59,15 @@ def _run(test_name):
 
     logpdf = input_dict["func"]
 
-    python_result = adaptive_rejection_sampling(
-        logpdf=logpdf, a=a, b=b, domain=domain, n_samples=n_samples, seed=1
-    )
+    if use_random_stream:
+        python_result = adaptive_rejection_sampling(
+            logpdf=logpdf, a=a, b=b, domain=domain, n_samples=n_samples, seed=1
+        )
+    else:
+        python_result = adaptive_rejection_sampling(
+            logpdf=logpdf, a=a, b=b, domain=domain, n_samples=n_samples,
+            random_stream=np.random.RandomState(seed=1)
+        )
 
     # load old result computed by other implementation (julia)
     julia_result = np.load(input_dict["data"])
@@ -70,12 +76,15 @@ def _run(test_name):
 
 
 def test_gaussian():
-    _run("1d-gaussian")
+    _run("1d-gaussian", True)
+    _run("1d-gaussian", False)
 
 
 def test_half_gaussian():
-    _run("1d-half-gaussian")
+    _run("1d-half-gaussian", True)
+    _run("1d-half-gaussian", False)
 
 
 def test_relativistic_monte_carlo_logpdf():
-    _run("relativistic_monte_carlo_logpdf")
+    _run("relativistic_monte_carlo_logpdf", True)
+    _run("relativistic_monte_carlo_logpdf", False)


### PR DESCRIPTION
Adding the ability to optionally pass a seeded NumPy `RandomState` object (or object with an equivalent interface) instead of an integer seed via a `random_stream` argument. This is helpful when the calling code already has seeded a `RandomState` object and it's desired to use this object to generate all random draws within an overall algorithm (e.g. when using the `adaptive_rejection_sampling` routine within a MCMC algorithm which involves making other random draws in each iteration). 

While it is possible in existing implementation to pass a integer seed to the  `adaptive_rejection_sampling` function which has been generated from the external `RandomState` to achieve consistent output on repeated runs, this both is a bit inefficient when only a few samples are being generated in each  `adaptive_rejection_sampling` call as a new `RandomState` object is instantiated on each call,  but more importantly I think it can also introduce biases as the initial few draws from a `RandomState` seeded with 32-bit integers will be subject to [initial transient effects in the underlying Mersenne-Twister state](http://www.pcg-random.org/posts/cpp-seeding-surprises.html).

I've tried to keep the changes consistent with the existing code and such that backwards compatibility is maintained and added a few tests by adding an optional switch to the existing test functions.